### PR TITLE
Don't try to set proxy if environment variable http_proxy is undefined

### DIFF
--- a/libexec/rbenv-install.vbs
+++ b/libexec/rbenv-install.vbs
@@ -233,7 +233,7 @@ Function DownloadFile(strUrl,strFile)
         Wscript.Quit
     end if
     httpProxy = objws.ExpandEnvironmentStrings("%http_proxy%")
-    if httpProxy <> "" Then
+    if httpProxy <> "" AND httpProxy <> "%http_proxy%" Then
     	objHttp.setProxy 2, httpProxy
     end if
     objHttp.Send


### PR DESCRIPTION
ExpandEnvironmentStrings("%http_proxy%") will return "%http_proxy%" if undefined, which will cause this being set as a proxy.