### PR TITLE
Generate sh shims for MinGW environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/bin/
 /bin/*
 !/bin/rbenv.bat
+!/bin/rbenv
 
 !/libexec/
 /libexec/*

--- a/bin/rbenv
+++ b/bin/rbenv
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cmd //c call "$(dirname "$0")/rbenv.bat" $*

--- a/libexec/rbenv.vbs
+++ b/libexec/rbenv.vbs
@@ -173,6 +173,10 @@ Sub CommandRehash(arg)
           ofile.WriteLine("@echo off")
           ofile.WriteLine("rbenv exec %~n0 %*")
           ofile.Close()
+          Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( file ) )
+          ofile.WriteLine("#!/bin/sh")
+          ofile.WriteLine("rbenv exec $(basename ""$0"") $*")
+          ofile.Close()
         End If
     Next
     
@@ -214,6 +218,14 @@ Sub CommandRehash(arg)
             ofile.WriteLine(") else (")
             ofile.WriteLine("bundle exec %~n0 %*")
             ofile.WriteLine(")")
+            ofile.Close()
+            Set ofile = objfs.CreateTextFile(strDirShims & "\" & objfs.GetBaseName( str ) )
+            ofile.WriteLine("#!/bin/sh")
+            ofile.WriteLine("if bundle show >/dev/null; then")
+            ofile.WriteLine("bundle exec $(basename ""$0"") $*")
+            ofile.WriteLine("else")
+            ofile.WriteLine("rbenv exec $(basename ""$0"") $*")
+            ofile.WriteLine("fi")
             ofile.Close()
         Loop
     end if


### PR DESCRIPTION
The bash shell from MinGW does not execute `.bat` files without their extension like `cmd.exe` does. This PR allows the user to call `rbenv install` and shims like `ruby` from a MinGW shell.